### PR TITLE
ci: switch CI to manual (workflow_dispatch) and add concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: CI
 
 on:
-  push:
-    branches: [develop, main]
-  pull_request:
+  workflow_dispatch: {}
 
 jobs:
   test:
@@ -21,3 +19,6 @@ jobs:
       - name: Run tests
         run: pytest -q
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true


### PR DESCRIPTION
BREAKING CHANGE: CI no longer runs automatically on push/PR. Update branch protection rules or add a lightweight PR workflow.

## Qué cambia
- [x] Nueva función
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Tests

## Descripción
- switch CI to manual (workflow_dispatch) and add concurrency
- BREAKING CHANGE: CI no longer runs automatically on push/PR. Update branch protection rules or add a lightweight PR workflow.

## Cómo probar
n/a

## Checklist
- [ ] Tests pasan (`pytest`)
- [ ] Estilo (`pre-commit run --all-files`)
- [ ] Actualicé docs si aplica

